### PR TITLE
Put the Jekyll plugin in the dedicated group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,12 +20,9 @@ gem "minima", "~> 2.0"
 
 # If you have any plugins, put them here!
 group :jekyll_plugins do
-   gem "jekyll-feed", "~> 0.6"
+  gem "jekyll-feed", "~> 0.6"
+  gem 'jekyll-autoprefixer'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
-
-# Jekyll plugins
-gem 'jekyll-autoprefixer'
-


### PR DESCRIPTION
This group is used by Jekyll to load the plugins