### PR TITLE
Correctif performances Chrome/Safari

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,6 +10,7 @@
 	  <link rel="stylesheet" type="text/css" href="/assets/css/main.css">
   </head>
   <body>
+    <div class="body-bg"></div>
     {% if layout.navigation == true %}
     {% include nav.html %}
     {% endif %}

--- a/_sass/base/_body.scss
+++ b/_sass/base/_body.scss
@@ -1,12 +1,20 @@
 body {
-	min-height: 100vw;
+	min-height: 100vh;
 	width: auto;
-	background: url("../images/bg.jpg");
-  background-color: #ccc;
-	background-attachment: fixed;
-	background-size: cover;
+  background: #ccc;
 	position: relative;
   padding: 3.5rem 1rem;
 	margin: 0;
   color: $color-text;
+}
+
+.body-bg {
+  background: url("../images/bg.jpg");
+  background-size: cover;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: -1;
 }


### PR DESCRIPTION
Gros soucis de perfs au scroll chez moi sur Chrome Mac. Je passe le background fixe sur une div vide plutôt que body pour corriger.

À tester ! J'ai fait ça à l'aveugle via l'inspecteur directement sur le site en ligne, je ne sais pas comment installer le site en local :)